### PR TITLE
Fixes for deprected warning now shown as errors in latest pytest version

### DIFF
--- a/pytest_cafy/__init__.py
+++ b/pytest_cafy/__init__.py
@@ -1,7 +1,7 @@
 '''
 Created on Feb 16, 2017
 
-@author: Fahad Naeem Khan
+@author: Amrendra Kumar
 '''
 
 from .__version__ import __version__

--- a/pytest_cafy/cafy.py
+++ b/pytest_cafy/cafy.py
@@ -1,0 +1,108 @@
+"""
+Cafy Placeholder class for pytest integeration
+"""
+
+from allure_commons._allure import StepContext as AllureStepContext
+
+class Cafy:
+    class CafyBaseException(Exception):
+        pass
+
+    class CompositeError(CafyBaseException):
+        def __init__(self, exceptions):
+            self.exceptions = self.flatten_exceptions(exceptions)
+
+        def flatten_exceptions(self,exceptions):
+            exception_list = list()
+            for exception in exceptions:
+                print(exception)
+                if isinstance(exception,Cafy.CompositeError):
+                    exception_list += self.flatten_exceptions(exception.exceptions)
+                elif isinstance(exception,list):
+                    exception_list += self.flatten_exceptions(exception)
+                else:
+                    exception_list.append(exception)
+            return exception_list
+
+        def __str__(self):
+            result = "Composite Error: \n"
+            for e in self.exceptions:
+                filename = ""
+                lineno = ""
+                if e.__traceback__:
+                    filename = e.__traceback__.tb_frame.f_code.co_filename
+                    lineno = e.__traceback__.tb_lineno
+                result += "    {filename}:{lineno}:{etype}({message})\n".format(
+                    filename=filename,
+                    lineno=lineno,
+                    etype=e.__class__.__name__,
+                    message=str(e))
+            return result
+
+        def __xrepr__(self):
+            return self.__str__()
+
+    class Globals: 
+        pass
+    
+    class RunInfo:
+        current_testcase = None
+        current_failures = dict()
+        active_exceptions = list()
+
+
+    class TestcaseStatus:
+        def __init__(self,name,status,message):
+            self.name = name
+            self.status = status
+            self.message = message
+
+    def step(title, **kwargs):
+        if callable(title):
+            return Cafy.StepContext(title.__name__, {}, **kwargs)(title)
+        else:
+            return Cafy.StepContext(title, {}, **kwargs)
+
+
+    class StepContext(AllureStepContext):
+        def __init__(self, title, params, logger=None, blocking=True):
+            super().__init__(title, params)
+            self.blocking = blocking
+            self.logger = logger
+
+        def __enter__(self):
+            super().__enter__()
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            super().__exit__(exc_type, exc_val, exc_tb)
+            if not self.blocking:
+                if exc_type:
+                    self.logger.error("Step failed here: {exc_type}:{exc_val}".format(
+                        exc_val=exc_val,
+                        exc_type=exc_type,
+                        exc_tb=exc_tb))
+                    Cafy.RunInfo.active_exceptions.append(exc_val)
+
+            return not self.blocking
+
+        
+    class StepScope():
+        def __init__(self, title):
+            self.title = title
+
+        def __enter__(self):
+            Cafy.RunInfo.active_exceptions = list()
+            Cafy.RunInfo.current_failures[Cafy.RunInfo.current_testcase] = list()
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            if Cafy.RunInfo.active_exceptions:
+                new_list = list()
+                for exc in Cafy.RunInfo.active_exceptions:
+                    new_list.append(exc)
+                Cafy.RunInfo.active_exceptions = list()
+                raise Cafy.CompositeError(new_list)
+
+            Cafy.RunInfo.current_failures[Cafy.RunInfo.current_testcase] = list()
+
+    def scope(title="Cafy Scope"):
+        return Cafy.StepScope(title=title)

--- a/pytest_cafy/plugin.py
+++ b/pytest_cafy/plugin.py
@@ -547,7 +547,7 @@ def pytest_collection_modifyitems(session, config, items):
         #Send the TestCases and its status(upcoming) collected to http://cafy3-dev-lnx:3100 for live logging
         try:
             for item in items:
-                if not item.get_marker('Future'):  #Exclude the Future marked testcases to be shown as upcoming
+                if not item.get_closest_marker('Future'):  #Exclude the Future marked testcases to be shown as upcoming
                     nodeid = item.nodeid.split('::()::')
                     finer_nodeid = nodeid[0].split('::')
                     class_name = finer_nodeid[-1]
@@ -826,7 +826,7 @@ class EmailReport(object):
         :param request:
         :return:
         '''
-        marker = request.node.get_marker('autofail')  # Is always None
+        marker = request.node.get_closest_marker('autofail')  # Is always None
         if not marker:
             return
         if bool(marker):


### PR DESCRIPTION
Dont merge this PR unless pytest is upgraded to version >=3.6
Allure2 requires pytest version >=3.3, our current pytest version as of Jan 18, 2018 is 3.0