### PR TITLE
Create cafyrun alias to run pytest scripts JIRA issue CAFY-260

### DIFF
--- a/bin/cafyrun
+++ b/bin/cafyrun
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import pytest
+import _pytest.main
+import sys
+
+# Customize messages for pytest exit codes
+msg = {_pytest.main.EXIT_OK: 'OK',
+       _pytest.main.EXIT_TESTSFAILED: 'Tests failed',
+       _pytest.main.EXIT_INTERRUPTED: 'Interrupted',
+       _pytest.main.EXIT_INTERNALERROR: 'Internal error',
+       _pytest.main.EXIT_USAGEERROR: 'Usage error',
+       _pytest.main.EXIT_NOTESTSCOLLECTED: 'No tests collected'}
+
+exitcode = pytest.main(sys.argv[1:])
+
+
+
+
+print(msg[exitcode])
+sys.exit(exitcode)
+

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     url='https://github.com/kuamrend/cafy-pytest',
     description='Pytest Cafy Plugin', 	
     install_requires=['pytest>=2.3', 'jinja2'],
+    scripts=['bin/cafyrun'],
     # the following makes a plugin available to pytest
     entry_points={
         'pytest11': ['pytest_cafy = pytest_cafy.plugin']


### PR DESCRIPTION
Create cafyrun alias to run pytest scripts JIRA issue CAFY-260
Created a bin folder and added cafyrun file(without the .py extension because we want the alias to be cafyrun and not cafyrun.py) and added the 'scripts' attribute in setup.py pointing to this cafyrun file