### PR TITLE
add mail-if-fail option for skipping email on all pass

### DIFF
--- a/pytest_cafy/plugin.py
+++ b/pytest_cafy/plugin.py
@@ -121,6 +121,8 @@ def pytest_addoption(parser):
                     help='smtp server port e.g 25')
     group.addoption('--no-email', dest='no_email', action='store_true',
                     help='if specified no email will be sent')
+    group.addoption('--mail-if-fail', dest='mail_if_fail', action='store_true',
+                    help='if specified, email will be sent only total testcase = passed testcases')
 
     group = parser.getgroup('Work Dir Path')
     group.addoption('--work-dir', dest="workdir", metavar="DIR", default=None,
@@ -1666,6 +1668,8 @@ class CafyReportData(object):
         self.xpassed = len(xpassed_list)
         self.xfailed = len(xfailed_list)
         self.total = self.passed + self.failed + self.skipped + self.xpassed + self.xfailed
+        if self.terminalreporter.config.option.mail_if_fail is True and self.total == self.passed and self.total != 0:
+            self.terminalreporter.config._email.no_email = True
         # testcase summary result
         self.testcase_name = testcase_dict.keys()
         if CafyLog.htmlfile_link:


### PR DESCRIPTION
Added an optional argument to skip emails in case of passing runs. This is for cases where the user only needs to be notified in cases of failure. UT/bake etc.

test env for this change is created here: /auto/boxr/anandja/test

Additional option
pytest test/parsers -k grid --mail-if-fail
--> will not send email

Default behavior
pytest test/parsers -k grid
--> will send email

if no test collected 
pytest test/parsers -k asdasd  --> will send email
pytest test/parsers -k asdasdas --mail-if-fail --> will send email

works with additional parameters like --mail-to and from
 pytest test/parsers -k griasdasd --mail-if-fail --mail-to cafyops@cisco.com --> will send email
 pytest test/parsers -k grid--mail-if-fail --mail-to cafyops@cisco.com --> will not send email