### PR TITLE
snapshot enable

### DIFF
--- a/cafy_pytest/cls_debug.py
+++ b/cafy_pytest/cls_debug.py
@@ -295,6 +295,8 @@ class DebugAdapter:
            
     def collector_call_snapshot(self, params, headers):
         """_summary_
+        This function initiates a data snapshot collection process.
+        It then polls a status endpoint to monitor the collection's completion.
 
         Args:
             params (dict) : dictionary of parameters sent to collector service.

--- a/cafy_pytest/cls_debug.py
+++ b/cafy_pytest/cls_debug.py
@@ -292,6 +292,52 @@ class DebugAdapter:
                 self.logger.warning(f'Error {e}')
                 self.logger.warning(f'Http call to registration service url:{url} is not successful')
                 return None
+           
+    def collector_call_snapshot(self, params, headers):
+        """_summary_
+
+        Args:
+            params (dict) : dictionary of parameters sent to collector service.
+            headers (dict): {'content-type': 'application/json'}
+
+        Returns:
+            response or None
+
+        """
+        if self.debug_server is None:
+            self.logger.info("debug_server name not provided in topo file")
+            return None
+        else:
+            url = f'http://{self.debug_server}:5001/startsnapshot/'
+            try:
+                self.logger.info(f'Calling registration service (url:{url}) to start collecting')
+                response = requests_retry(self.logger, url, 'POST', json=params, headers=headers, timeout=600)
+                if response.status_code == 200:
+                    waiting_time = 0
+                    poll_flag = True
+                    while(poll_flag):
+                        # Changed from /collectionstatus/ to /snapshotstatus/ as requested
+                        url_status = f'http://{self.debug_server}:5001/snapshotstatus/'
+                        response = requests_retry(self.logger, url_status, 'POST', json=params, headers=headers, timeout=30)
+                        if response.status_code == 200:
+                            message = response.json()
+                            if message["snapshot_status"] == True: # Assuming "collector_status" key remains relevant for snapshot status
+                                return response
+                            else:
+                                time.sleep(30)
+                                waiting_time = waiting_time + 30
+                                if waiting_time > 600:
+                                    poll_flag = False
+                        else:
+                            poll_flag = False
+                            self.logger.info(f'collection status api return status other then 200 response {response.status_code}')
+                else:
+                    self.logger.warning(f'start_debug part of handshake server returned code {response.status_code}')
+                    return None
+            except Exception as e:
+                self.logger.warning(f'Error {e}')
+                self.logger.warning(f'Http call to registration service url:{url} is not successful')
+                return None
 
     def rc_call(self, params, headers):
         """_summary_

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -386,6 +386,7 @@ def pytest_configure(config):
     #setting for global access
     CafyLog.debug_enable = cafykit_debug_enable
     cafykit_snapshot_enable = config.option.snapshot_enable
+    CafyLog.snapshot_enable = cafykit_snapshot_enable
     CafyLog.topology_file = config.option.topology_file
     CafyLog.test_input_file = config.option.test_input_file
     CafyLog.tag_file = config.option.tag_file
@@ -1464,7 +1465,7 @@ class EmailReport(object):
                 if not self.first_failure_detected:
                     self.first_failure_detected = True
                     self.first_failed_testcase_name = testcase_name
-                    if self.reg_dict and cafykit_snapshot_enable:
+                    if self.reg_dict and CafyLog.snapshot_enable:
                         headers = {'content-type': 'application/json'}
                         params = {"testcase_name": testcase_name,
                                   "reg_dict": self.reg_dict,
@@ -1511,7 +1512,7 @@ class EmailReport(object):
                     if not self.first_failure_detected:
                         self.first_failure_detected = True
                         self.first_failed_testcase_name = testcase_name
-                        if self.reg_dict and cafykit_snapshot_enable:
+                        if self.reg_dict and CafyLog.snapshot_enable:
                             headers = {'content-type': 'application/json'}
                             params = {"testcase_name": testcase_name,
                                       "reg_dict": self.reg_dict,
@@ -1532,7 +1533,7 @@ class EmailReport(object):
                         if not self.first_failure_detected:
                             self.first_failure_detected = True
                             self.first_failed_testcase_name = testcase_name
-                            if self.reg_dict and cafykit_snapshot_enable:
+                            if self.reg_dict and CafyLog.snapshot_enable:
                                 headers = {'content-type': 'application/json'}
                                 params = {"testcase_name": testcase_name,
                                           "reg_dict": self.reg_dict,

--- a/cafy_pytest/plugin.py
+++ b/cafy_pytest/plugin.py
@@ -204,6 +204,8 @@ def pytest_addoption(parser):
     group = parser.getgroup('Cafykit Debug ')
     group.addoption('--debug-enable', dest='debug_enable', action='store_true',
                     help='Variable to enable cafykit debug, default is False')
+    group.addoption('--snapshot-enable', dest='snapshot_enable', action='store_true',
+                    help='Variable to enable snapshot, default is False')
 
     group = parser.getgroup('Script Arguments')
     group.addoption('--script-args', action='store', dest='script_args',
@@ -383,6 +385,7 @@ def pytest_configure(config):
     cafykit_debug_enable = config.option.debug_enable
     #setting for global access
     CafyLog.debug_enable = cafykit_debug_enable
+    cafykit_snapshot_enable = config.option.snapshot_enable
     CafyLog.topology_file = config.option.topology_file
     CafyLog.test_input_file = config.option.test_input_file
     CafyLog.tag_file = config.option.tag_file
@@ -902,6 +905,8 @@ class EmailReport(object):
         self.cafypdb = cafypdb
         self.debugger_quit = False
         self.cafypdb_user_action = ''
+        self.first_failure_detected = False
+        self.first_failed_testcase_name = None
 
     def _sendemail(self):
         print("\nSending Summary Email to %s" % self.email_addr_list)
@@ -1344,6 +1349,7 @@ class EmailReport(object):
             if CafyLog.debug_enable:
                 register_object.register_testcase(testcase_name=testcase_name)
 
+
         if report.when == 'teardown':
             status = "unknown"
             if testcase_name in self.testcase_dict:
@@ -1455,6 +1461,17 @@ class EmailReport(object):
            testcase_status = report.outcome
            self.testcase_dict[testcase_name] = Cafy.TestcaseStatus(testcase_name,testcase_status,report.longrepr)
            if testcase_status == 'failed':
+                if not self.first_failure_detected:
+                    self.first_failure_detected = True
+                    self.first_failed_testcase_name = testcase_name
+                    if self.reg_dict and cafykit_snapshot_enable:
+                        headers = {'content-type': 'application/json'}
+                        params = {"testcase_name": testcase_name,
+                                  "reg_dict": self.reg_dict,
+                                  "debug_server_name": CafyLog.debug_server}
+                        self.invoke_reg_on_failed_testcase_snapshot(params, headers)
+                    self.log.error(f"FIRST FAILURE DETECTED: Test case '{testcase_name}' failed during setup.")
+
                 if report.longrepr:
                     self.temp_json["stack_exception"] = str(report.longrepr)
                 else:
@@ -1491,6 +1508,17 @@ class EmailReport(object):
 
                 self.testcase_dict[testcase_name] = Cafy.TestcaseStatus(testcase_name,testcase_status,report.longrepr)
                 if testcase_status == 'failed':
+                    if not self.first_failure_detected:
+                        self.first_failure_detected = True
+                        self.first_failed_testcase_name = testcase_name
+                        if self.reg_dict and cafykit_snapshot_enable:
+                            headers = {'content-type': 'application/json'}
+                            params = {"testcase_name": testcase_name,
+                                      "reg_dict": self.reg_dict,
+                                      "debug_server_name": CafyLog.debug_server}
+                            self.invoke_reg_on_failed_testcase_snapshot(params, headers)
+                        self.log.error(f"FIRST FAILURE DETECTED: Test case '{testcase_name}' failed during setup.")
+                if report.longrepr:
                     self.testcase_failtrace_dict[testcase_name] = CafyLog.fail_log_msg
                     if report.longrepr:
                         self.temp_json["stack_exception"] = str(report.longrepr)
@@ -1501,6 +1529,16 @@ class EmailReport(object):
                 self.testcase_dict[testcase_name] = Cafy.TestcaseStatus(testcase_name,testcase_status,report.longrepr)
                 if testcase_status == 'failed':
                     if report.longrepr:
+                        if not self.first_failure_detected:
+                            self.first_failure_detected = True
+                            self.first_failed_testcase_name = testcase_name
+                            if self.reg_dict and cafykit_snapshot_enable:
+                                headers = {'content-type': 'application/json'}
+                                params = {"testcase_name": testcase_name,
+                                          "reg_dict": self.reg_dict,
+                                          "debug_server_name": CafyLog.debug_server}
+                                self.invoke_reg_on_failed_testcase_snapshot(params, headers)
+                            self.log.error(f"FIRST FAILURE DETECTED: Test case '{testcase_name}' failed during call.")
                         self.testcase_failtrace_dict[testcase_name] = report.longrepr
                         self.temp_json["stack_exception"]=str(report.longrepr)
                         self.log.error("stack_exception %s" %report.longrepr)
@@ -1983,6 +2021,15 @@ class EmailReport(object):
         :param headers: headers associated with api request call
         """
         return register_object.collector_call(params=params, headers=headers)
+
+    def invoke_reg_on_failed_testcase_snapshot(self, params, headers):
+        """
+        will call debug service api to start collection
+        :param params: failure details of testcase for given run
+        :param headers: headers associated with api request call
+        """
+        self.log.info(f"Invoking snapshot collection for first failure with params: {params}")
+        return register_object.collector_call_snapshot(params=params, headers=headers)
     
 
     def invoke_rc_on_failed_testcase(self, params, headers):
@@ -2194,6 +2241,7 @@ class EmailReport(object):
                       "input_file": CafyLog.test_input_file}
             headers = {'content-type': 'application/json'}
             register_object.collector_log(params=params, headers=headers, work_dir=CafyLog.work_dir)
+
 
         try:
             with open(os.path.join(CafyLog.work_dir, "retest_data.json"), "w") as f:


### PR DESCRIPTION
this PR aims to enable snapshot collection in pytest upon the first test failure. This functionality would be activated using the pytest argument --snapshot-enable.

http://cafy-web-ott2:8080/job/test_cafyap_exec_pytest/62169/console